### PR TITLE
добавлена команда "rhvoice_say"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .idea
+tools/build

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from .preprocessing.text_prepare import text_prepare as do_prepare
+
+
+def text_prepare(text):
+    return do_prepare(text)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from .preprocessing.text_prepare import text_prepare as do_prepare
-
-
-def text_prepare(text):
-    return do_prepare(text)
+from .preprocessing.text_prepare import text_prepare
+from .rhvoice_say import rhvoice_say

--- a/tools/build.py
+++ b/tools/build.py
@@ -13,7 +13,7 @@ try:
 except:
     pass
 
-dest_dir = "build/lib/%s/rhvoice_preprocessing" % site_pkg
+dest_dir = "build/lib/%s/rhvoice_tools" % site_pkg
 
 makedirs(dest_dir + '/preprocessing/dict')
 

--- a/tools/build.py
+++ b/tools/build.py
@@ -18,6 +18,7 @@ dest_dir = "build/lib/%s/rhvoice_preprocessing" % site_pkg
 makedirs(dest_dir + '/preprocessing/dict')
 
 files = ['__init__.py',
+         'rhvoice_say.py',
          'preprocessing/functions.py',
          'preprocessing/rules.py',
          'preprocessing/templates.py',

--- a/tools/build.py
+++ b/tools/build.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from sys import version_info
+from os import makedirs
+from shutil import copyfile, rmtree
+
+
+site_pkg = "python%d.%d/site-packages" % (version_info.major, version_info.minor)
+
+try:
+    rmtree('build')
+except:
+    pass
+
+dest_dir = "build/lib/%s/rhvoice_preprocessing" % site_pkg
+
+makedirs(dest_dir + '/preprocessing/dict')
+
+files = ['__init__.py',
+         'preprocessing/functions.py',
+         'preprocessing/rules.py',
+         'preprocessing/templates.py',
+         'preprocessing/text_prepare.py',
+         'preprocessing/words_forms.py',
+         'preprocessing/dict/words_muz.py',
+         'preprocessing/dict/words_sre.py',
+         'preprocessing/dict/words_zen.py'
+        ]
+for file in files:
+    copyfile(file, "%s/%s" % (dest_dir, file))

--- a/tools/rhvoice_say
+++ b/tools/rhvoice_say
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
-from rhvoice_preprocessing.rhvoice_say import rhvoice_say
+from rhvoice_tools import rhvoice_say
 
 
 if len(sys.argv) > 1:

--- a/tools/rhvoice_say
+++ b/tools/rhvoice_say
@@ -5,4 +5,8 @@ import sys
 from rhvoice_preprocessing.rhvoice_say import rhvoice_say
 
 
-rhvoice_say(sys.argv)
+if len(sys.argv) > 1:
+    text = sys.argv[1]
+    rhvoice_say(text)
+else:
+    print('Нет текста для чтения...')

--- a/tools/rhvoice_say
+++ b/tools/rhvoice_say
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+import subprocess
+import configparser
+from os.path import exists as path_exists
+from os.path import expanduser
+from rhvoice_preprocessing import text_prepare
+
+
+args = sys.argv
+
+if len(args) > 1:
+    """
+    Чтение текста RHVocie с предварительнгой обработкой текста.
+    """
+    txt = text_prepare(args[1])        # предварительная подготовка текста
+
+    # открываем файл конфигурации
+    file_name = expanduser("~") + '/.rhvoice_say.conf'
+    config = configparser.ConfigParser()
+    if not path_exists(file_name):
+        # если файл отсутствует, создаем новый со стандартными настройками
+        config['Settings'] = {'use_speech_dispatcher': 'False',
+                              'voice': 'Aleksandr+Alan'}
+        with open(file_name, 'w') as configfile:
+            config.write(configfile)
+    config.read(file_name)
+    settings = config['Settings']
+    use_SD = settings.getboolean('use_speech_dispatcher')
+    voice = settings.get('voice')
+
+    if use_SD:
+        # -e, --pipe-mode (Pipe from stdin to stdout plus Speech Dispatcher)
+        # -w, --wait (Wait till the message is spoken or discarded)
+        # -y, --synthesis-voice (Set the synthesis voice)
+        p = subprocess.Popen(['spd-say', "-e", "-w", "-y" + voice],
+                             stdin=subprocess.PIPE)
+    else:
+        # -p <spec>, --profile <spec> (voice profile)
+        p = subprocess.Popen(['RHVoice-test', "-p " + voice],
+                             stdin=subprocess.PIPE)
+    p.communicate(txt.encode('utf-8'))
+else:
+    print('Нет текста для чтения...')

--- a/tools/rhvoice_say
+++ b/tools/rhvoice_say
@@ -2,45 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
-import subprocess
-import configparser
-from os.path import exists as path_exists
-from os.path import expanduser
-from rhvoice_preprocessing import text_prepare
+from rhvoice_preprocessing.rhvoice_say import rhvoice_say
 
 
-args = sys.argv
-
-if len(args) > 1:
-    """
-    Чтение текста RHVocie с предварительнгой обработкой текста.
-    """
-    txt = text_prepare(args[1])        # предварительная подготовка текста
-
-    # открываем файл конфигурации
-    file_name = expanduser("~") + '/.rhvoice_say.conf'
-    config = configparser.ConfigParser()
-    if not path_exists(file_name):
-        # если файл отсутствует, создаем новый со стандартными настройками
-        config['Settings'] = {'use_speech_dispatcher': 'False',
-                              'voice': 'Aleksandr+Alan'}
-        with open(file_name, 'w') as configfile:
-            config.write(configfile)
-    config.read(file_name)
-    settings = config['Settings']
-    use_SD = settings.getboolean('use_speech_dispatcher')
-    voice = settings.get('voice')
-
-    if use_SD:
-        # -e, --pipe-mode (Pipe from stdin to stdout plus Speech Dispatcher)
-        # -w, --wait (Wait till the message is spoken or discarded)
-        # -y, --synthesis-voice (Set the synthesis voice)
-        p = subprocess.Popen(['spd-say', "-e", "-w", "-y" + voice],
-                             stdin=subprocess.PIPE)
-    else:
-        # -p <spec>, --profile <spec> (voice profile)
-        p = subprocess.Popen(['RHVoice-test', "-p " + voice],
-                             stdin=subprocess.PIPE)
-    p.communicate(txt.encode('utf-8'))
-else:
-    print('Нет текста для чтения...')
+rhvoice_say(sys.argv)

--- a/tools/rhvoice_say.py
+++ b/tools/rhvoice_say.py
@@ -9,12 +9,12 @@ from os.path import expanduser
 from rhvoice_preprocessing import text_prepare
 
 
-def rhvoice_say(args):
-    if len(args) > 1:
+def rhvoice_say(text):
+    if text:
         """
         Чтение текста RHVocie с предварительнгой обработкой текста.
         """
-        txt = text_prepare(args[1])        # предварительная подготовка текста
+        txt = text_prepare(text)        # предварительная подготовка текста
 
         # открываем файл конфигурации
         file_name = expanduser("~") + '/.config/rhvoice_say.conf'

--- a/tools/rhvoice_say.py
+++ b/tools/rhvoice_say.py
@@ -6,7 +6,7 @@ import subprocess
 import configparser
 from os.path import exists as path_exists
 from os.path import expanduser
-from rhvoice_preprocessing import text_prepare
+from rhvoice_tools import text_prepare
 
 
 def rhvoice_say(text):

--- a/tools/rhvoice_say.py
+++ b/tools/rhvoice_say.py
@@ -17,11 +17,21 @@ def rhvoice_say(args):
         txt = text_prepare(args[1])        # предварительная подготовка текста
 
         # открываем файл конфигурации
-        file_name = expanduser("~") + '/.rhvoice_say.conf'
-        config = configparser.ConfigParser()
+        file_name = expanduser("~") + '/.config/rhvoice_say.conf'
+        config = configparser.ConfigParser(allow_no_value=True)
+        # с учетом регистра
+        config.optionxform = str
         if not path_exists(file_name):
             # если файл отсутствует, создаем новый со стандартными настройками
-            config['Settings'] = {'use_speech_dispatcher': 'False',
+            config['Settings'] = {"; Использовать Speech Dispatcher для чтения ('True' или 'False')": None,
+                                  'use_speech_dispatcher': False,
+                                  '; Громкость в процентах (от -100 до 100)': None,
+                                  'volume': 0,
+                                  '; Скорость в процентах (от -100 до 100)': None,
+                                  'rate': 0,
+                                  '; Высота в процентах (от -100 до 100)': None,
+                                  'pitch': 0,
+                                  '; Голос для чтения': None,
                                   'voice': 'Aleksandr+Alan'}
             with open(file_name, 'w') as configfile:
                 config.write(configfile)
@@ -29,16 +39,39 @@ def rhvoice_say(args):
         settings = config['Settings']
         use_SD = settings.getboolean('use_speech_dispatcher')
         voice = settings.get('voice')
+        volume = settings.getint('volume')
+        rate = settings.getint('rate')
+        pitch = settings.getint('pitch')
 
         if use_SD:
             # -e, --pipe-mode (Pipe from stdin to stdout plus Speech Dispatcher)
             # -w, --wait (Wait till the message is spoken or discarded)
             # -y, --synthesis-voice (Set the synthesis voice)
-            p = subprocess.Popen(['spd-say', "-e", "-w", "-y" + voice],
+            # -r, --rate (Set the rate of the speech)
+            #            (between -100 and +100, default: 0)
+            # -i, --volume (Set the volume (intensity) of the speech)
+            #              (between -100 and +100, default: 0)
+            # -p, --pitch (Set the pitch of the speech)
+            #             (between -100 and +100, default: 0)
+            p = subprocess.Popen(['spd-say',
+                                  "-e", "-w",
+                                  "-y" + voice,
+                                  "-i %d" % volume,
+                                  "-r %d" % rate,
+                                  "-p %d" % pitch
+                                  ],
                                  stdin=subprocess.PIPE)
         else:
             # -p <spec>, --profile <spec> (voice profile)
-            p = subprocess.Popen(['RHVoice-test', "-p " + voice],
+            # -r <percent>,  --rate <percent> (speech rate)
+            # -v <percent>,  --volume <percent> (speech volume)
+            # -t <percent>,  --pitch <percent> (speech pitch)
+            p = subprocess.Popen(['RHVoice-test',
+                                  "-p " + voice,
+                                  "-v %d" % (volume + 100),
+                                  "-r %d" % (rate + 100),
+                                  "-t %d" % (pitch + 100)
+                                  ],
                                  stdin=subprocess.PIPE)
         p.communicate(txt.encode('utf-8'))
     else:

--- a/tools/rhvoice_say.py
+++ b/tools/rhvoice_say.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+import subprocess
+import configparser
+from os.path import exists as path_exists
+from os.path import expanduser
+from rhvoice_preprocessing import text_prepare
+
+
+def rhvoice_say(args):
+    if len(args) > 1:
+        """
+        Чтение текста RHVocie с предварительнгой обработкой текста.
+        """
+        txt = text_prepare(args[1])        # предварительная подготовка текста
+
+        # открываем файл конфигурации
+        file_name = expanduser("~") + '/.rhvoice_say.conf'
+        config = configparser.ConfigParser()
+        if not path_exists(file_name):
+            # если файл отсутствует, создаем новый со стандартными настройками
+            config['Settings'] = {'use_speech_dispatcher': 'False',
+                                  'voice': 'Aleksandr+Alan'}
+            with open(file_name, 'w') as configfile:
+                config.write(configfile)
+        config.read(file_name)
+        settings = config['Settings']
+        use_SD = settings.getboolean('use_speech_dispatcher')
+        voice = settings.get('voice')
+
+        if use_SD:
+            # -e, --pipe-mode (Pipe from stdin to stdout plus Speech Dispatcher)
+            # -w, --wait (Wait till the message is spoken or discarded)
+            # -y, --synthesis-voice (Set the synthesis voice)
+            p = subprocess.Popen(['spd-say', "-e", "-w", "-y" + voice],
+                                 stdin=subprocess.PIPE)
+        else:
+            # -p <spec>, --profile <spec> (voice profile)
+            p = subprocess.Popen(['RHVoice-test', "-p " + voice],
+                                 stdin=subprocess.PIPE)
+        p.communicate(txt.encode('utf-8'))
+    else:
+        print('Нет текста для чтения...')


### PR DESCRIPTION
Использование из терминала: rhvoice_say "проверка связи"
Настройки в файле: `~/.config/rhvoice_say.conf`

Тажке сформирована в виде системного пакета обработка текста.
Теперь можно делать так в своих скриптах:
```
from rhvoice_tools import text_prepare, rhvoice_say

txt = text_prepare("текст для обработки")
rhvoice_say('2 проверка связи')
```

Вот [pkgbuild](https://pastebin.com/shf1dK9A), чтобы попробовать.