### PR TITLE
Revert "Получить данные из pipe/"трубы""

### DIFF
--- a/tools/rhvoice_say
+++ b/tools/rhvoice_say
@@ -11,8 +11,6 @@ def show_help():
           "               rhvoice_say -d 'текст для чтения'  -- режим отладки\n"
           "               rhvoice_say -h                     -- данная справка")
 
-data = sys.stdin.read()
-    
 if '-h' in sys.argv:
     show_help()
 elif '-c' in sys.argv:
@@ -23,8 +21,6 @@ elif '-d' in sys.argv and len(sys.argv) > 2:
 elif len(sys.argv) > 1:
     text = sys.argv[1]
     rhvoice_say(text)
-elif len(data):
-    rhvoice_say(data)
 else:
     print('Нет текста для чтения...')
     show_help()


### PR DESCRIPTION
Reverts vantu5z/RHVoice-dictionary#237
Причина: программа фризит без видимых причин на `sys.stdin.read()` если на вход подать обычный тест например `rhvoice_say 'привет'`, а не через pipe. 
Когда пойму, как обойти это приду с новым PR.